### PR TITLE
add: system related query

### DIFF
--- a/SQL Query/get_open_connections.sql
+++ b/SQL Query/get_open_connections.sql
@@ -1,0 +1,3 @@
+SELECT DB_NAME(dbid) as DBName, COUNT(dbid) as NumberOfConnections, loginam as LoginName, sum(cpu) CPU, hostname 
+FROM sys.sysprocessesWHEREdbid > 0
+--and login_time > '2022-08-23' and login_time < '2022-08-24'GROUP BYdbid, loginame,hostname;


### PR DESCRIPTION
adding queries to pull system processes information and details.
useful for SQL databases hosted in cloud systems such as Azure, GCP or AWS